### PR TITLE
Color

### DIFF
--- a/CC-Gen/CC-Gen.csproj
+++ b/CC-Gen/CC-Gen.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/CC-Gen/CC-Gen.csproj
+++ b/CC-Gen/CC-Gen.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="EsapiConnection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StructureDictionaryService.cs" />
     <Compile Include="StructureFromText.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CC-Gen/CC-Gen.csproj
+++ b/CC-Gen/CC-Gen.csproj
@@ -51,6 +51,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/CC-Gen/Properties/AssemblyInfo.cs
+++ b/CC-Gen/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.1.0")]
-[assembly: AssemblyFileVersion("1.2.1.0")]
+[assembly: AssemblyVersion("1.2.2.0")]
+[assembly: AssemblyFileVersion("1.2.2.0")]

--- a/CC-Gen/Properties/AssemblyInfo.cs
+++ b/CC-Gen/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("1.2.4.0")]
+[assembly: AssemblyFileVersion("1.2.4.0")]

--- a/CC-Gen/StructureDictionaryService.cs
+++ b/CC-Gen/StructureDictionaryService.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Xml.Serialization;
+
+namespace StructureBuilder
+{
+    internal static class StructureDictionaryService
+    {
+        internal static string ServerId;
+        internal static List<StructureNameDictionaryOfStringListOfString> StructureDictionary;
+        internal static void InitializeStructureDictionary()
+        {
+            string path = Path.Combine($"\\\\{ServerId}", "va_data$", "programdata", "vision", "visualscripting",
+                "structurenamedictionary.xml");
+            if (!File.Exists(path))
+            {
+                MessageBox.Show($"File path not found: {path}. Please check config file.");
+                return;
+            }
+            XmlSerializer xmlSerializer = new XmlSerializer(typeof(List<StructureNameDictionaryOfStringListOfString>));
+            //StructureDictionary = new List<StructureNameDictionary>();
+            using (StreamReader sr = new StreamReader(path))
+            {
+                StructureDictionary = (List<StructureNameDictionaryOfStringListOfString>)xmlSerializer.Deserialize(sr);
+            }
+        }
+        internal static List<string> GetDictionaryValues(string keyValue)
+        {
+            List<string> matches = new List<string>();
+            if (StructureDictionary != null)
+            {
+                if (StructureDictionary.Any(sd => sd.Key.Equals(keyValue, StringComparison.OrdinalIgnoreCase)))
+                {
+                    matches = StructureDictionary
+                        .First(sd => sd.Key.Equals(keyValue, StringComparison.OrdinalIgnoreCase)).Value;
+                }
+            }
+            return matches;
+        }
+    }
+    public class StructureNameDictionaryOfStringListOfString
+    {
+        public string Key { get; set; }
+        public List<string> Value { get; set; }
+    }
+}

--- a/CC-Gen/StructureFromText.cs
+++ b/CC-Gen/StructureFromText.cs
@@ -8,6 +8,7 @@ using VMS.TPS.Common.Model.Types;
 using OSU_Helpers;
 using System.Windows;
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace OSUStructureGenerator
 {
@@ -58,7 +59,15 @@ namespace OSUStructureGenerator
             //operations => [0]PTV     [1]Ring(5,20)    [2]CropOut(Body,3)
 
             //_Opti,AVOIDANCE
-            string[] id_and_type = target_and_operation[0].Split(',');
+            //check if color was provided prior to getting ID and type.
+            string id_part = target_and_operation[0];
+            string colorPart = String.Empty;
+            if (id_part.Contains("|"))
+            {
+                id_part = target_and_operation[0].Split('|').First();
+                colorPart = target_and_operation[0].Split('|').Last();
+            }
+            string[] id_and_type = id_part.Split(',');
             //id_and_type => [0]_Opti   [1]AVOIDANCE
 
             id = ValidateStructureID(id_and_type[0]);
@@ -87,7 +96,21 @@ namespace OSUStructureGenerator
 
                 }
             }
-
+            if (!String.IsNullOrEmpty(colorPart))
+            {
+                string[] colors = colorPart.Split(',');
+                if (colors.Length != 3)
+                {
+                    MessageBox.Show($"Color provided but incorrect format: {colorPart}");
+                }
+                else
+                {
+                    GeneratedStructure.Color = System.Windows.Media.Color.FromRgb(
+                        Convert.ToByte(Convert.ToInt16(colors.First())),
+                        Convert.ToByte(Convert.ToInt16(colors.ElementAt(1))),
+                        Convert.ToByte(Convert.ToInt16(colors.Last())));
+                }
+            }
             GeneratedStructure.SegmentVolume = GetSegmentVolumeFromBase(operations[0]);
             ApplyOperations(operations, line);
         }

--- a/OSU Helpers/OSU_Helpers/OSU_Helpers_Public.csproj
+++ b/OSU Helpers/OSU_Helpers/OSU_Helpers_Public.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,12 +54,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAPICodePack-Core.1.1.2\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\..\packages\WindowsAPICodePack-Core.1.1.2\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>..\..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -80,12 +79,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AriaConnection.cs" />
     <Compile Include="ControlPointExt.cs" />
-    <Compile Include="Gradient_Data.cs" />
     <Compile Include="SQLQuery.cs" />
     <Compile Include="BeamExt.cs" />
-    <Compile Include="CitrixServerSelection.cs" />
     <Compile Include="CourseExt.cs" />
     <Compile Include="DateTimeHelpers.cs" />
     <Compile Include="DICOMEntities.cs" />
@@ -101,8 +97,6 @@
     <Compile Include="MLC_Leaf.cs" />
     <Compile Include="PlanSetupExt.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SRT_Metrics.cs" />
-    <Compile Include="SRT_Metrics_Helper.cs" />
     <Compile Include="StandardDeviation.cs" />
     <Compile Include="StringHelpers.cs" />
     <Compile Include="StructureExt.cs" />
@@ -112,10 +106,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Gradient50Fits.txt" />
-    <EmbeddedResource Include="Gradient20Fits.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/OSU Helpers/OSU_Helpers/packages.config
+++ b/OSU Helpers/OSU_Helpers/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net452" />
-  <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net452" />
+  <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net472" />
+  <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Hi Dominic,

We added some small code in the lines 112-126 to support adding a color to the structure. The syntax is a "|" followed by the rgb values of the color: 
EX: zNS_O_Bo,CONTROL|255,255,0=Bowel_Small.And(zAll_PTVs).HighRes()

Additionally, we added an asterisk to the beginning of any line to request that the structure dictionary (from visual scripting) be used to match structure Ids.
Ex: *zNS_O_Bo,CONTROL|255,255,0=Bowel_Small.And(zAll_PTVs).HighRes()
The additionally structure dictionary service class and the changes to the method "GetStructureFromBase" in line 423-439.
Sincerely, GS401 Automation course November 2024.